### PR TITLE
Change Authorization Method via Authorization Header

### DIFF
--- a/src/Api/Utils/ApiClient.php
+++ b/src/Api/Utils/ApiClient.php
@@ -41,15 +41,25 @@ class ApiClient
     public function execute($httpMethod, $url, array $parameters = [])
     {
         try {
-            $parameters['token'] = $this->getToken();
-            $response = $this->getClient()->{$httpMethod}('api/v1/' . $url, ['json' => $parameters]);
+            $headers = [
+                'Authorization' => $this->getToken(),
+                'Accept' => 'application/json'
+            ];
+
+            $response = $this->getClient()->{$httpMethod}('api/v1/' . $url, [
+                'headers' => $headers,
+                'json' => $parameters
+            ]);
             $responseBody = json_decode((string)$response->getBody(), true);
             return $responseBody['objects'];
-        } catch (BadResponseException $exception) {
+        }
+        catch (BadResponseException $exception) {
             $response = json_decode((string)$exception->getResponse()->getBody(), true);
             if (array_key_exists('error', $response)) {
-                if ($response['error']['code'] == 151) throw new ModelNotFoundException($response['error']['message']);
-                if ($response['error']['message'] != null) throw new \Exception($response['error']['message']);;
+                if ($response['error']['code'] == 151) {
+                    throw new ModelNotFoundException($response['error']['message']);
+                }
+                if ($response['error']['message'] != null) throw new \Exception($response['error']['message']);
             }
             if (array_key_exists('status', $response)) {
                 if ($response['status'] == 401) throw new UnauthorizedException($response['message']);


### PR DESCRIPTION
**Background:** In early February, sevDesk issued a notification stating that they will be removing the option to send the API token inside the request body by the end of April. More details about this change can be found here: [sevDesk API Authentication Update](https://tech.sevdesk.com/api_news/posts/2025_02_06-authentication-method-removed/).

**Current Situation:** Currently, the laravel-sevdesk-api package sends the API token as part of the JSON payload when making API requests. Specifically, the token is included in the request body at this line of code: [ApiClient.php, line 44](https://github.com/exlo89/laravel-sevdesk-api/blob/main/src/Api/Utils/ApiClient.php#L44).

**Required Change:** In response to sevDesk's new policy, the API token needs to be moved from the JSON payload to the Authorization header of the request. From now on, sevDesk will only accept the API token inside the Authorization header, and using it in the body will no longer be supported.

**Implementation:** This change involves modifying the ApiClient class in the package to place the API token into the Authorization header for each API request, instead of including it in the body of the request. This will ensure compatibility with sevDesk's updated authentication method, which will become mandatory at the end of April.

**Issue Tracking:** This change has been tracked under [Issue #23](https://github.com/exlo89/laravel-sevdesk-api/issues/23), which outlines the details of the required modification in the package.