### PR TITLE
Fix: Ensure all method retrieves all invoices when exceeding 100 items

### DIFF
--- a/src/Api/Invoice.php
+++ b/src/Api/Invoice.php
@@ -32,7 +32,25 @@ class Invoice extends ApiClient
      */
     public function all(): Collection
     {
-        return Collection::make($this->_get(Routes::INVOICE));
+        $allInvoices = collect();
+        $offset = 0;
+        $limit = 100;
+
+        do {
+            // Add offset and limit to the parameters
+            $invoices = Collection::make($this->_get(Routes::INVOICE, [
+                'offset' => $offset,
+                'limit' => $limit,
+            ]));
+
+            // Add the new invoices to the existing collection
+            $allInvoices = $allInvoices->merge($invoices);
+            // Increase the offset by the number of invoices returned
+            $offset += $invoices->count();
+
+        } while ($invoices->count() === $limit); // Repeat as long as the maximum number is returned
+
+        return $allInvoices;
     }
 
     /**


### PR DESCRIPTION
I noticed an issue where the all() method only returns a maximum of 100 invoices due to API pagination. I've updated the method to properly handle pagination by iterating through all pages until no more invoices are returned. Please review and verify the changes.

Fixes #26 