### PR TITLE
fix(config): allow taxRate = 0/"0" and treat as valid per small business VAT exemption

### DIFF
--- a/src/Api/Utils/DocumentHelper.php
+++ b/src/Api/Utils/DocumentHelper.php
@@ -43,7 +43,7 @@ class DocumentHelper
      */
     static private function validateConfigs(array $configs): array
     {
-        if (empty($configs['taxRate'])) {
+        if (!array_key_exists('taxRate', $configs) || (is_string($configs['taxRate']) && trim($configs['taxRate']) === '')) {
             throw new Exception('Configuration parameter not found: tax_rate');
         }
         if (empty($configs['taxText'])) {

--- a/src/Api/Utils/DocumentHelper.php
+++ b/src/Api/Utils/DocumentHelper.php
@@ -43,7 +43,7 @@ class DocumentHelper
      */
     static private function validateConfigs(array $configs): array
     {
-        if (!array_key_exists('taxRate', $configs) || (is_string($configs['taxRate']) && trim($configs['taxRate']) === '')) {
+        if (!isset($configs['taxRate']) || $configs['taxRate'] === null || trim($configs['taxRate']) === '') {
             throw new Exception('Configuration parameter not found: tax_rate');
         }
         if (empty($configs['taxText'])) {


### PR DESCRIPTION
Replace empty() for taxRate with explicit existence and non-empty string check so 0/"0" is accepted intentionally.

**Context**
- Required due to Germany’s Kleinunternehmerregelung (small business VAT exemption), where invoices must not include VAT and a tax rate of 0 is valid.
---
**Details**
- Added explicit check for taxRate (isset + null + trim guard).
---
**Testing**
- taxRate: 0 and "0" accepted; null, "" and whitespace rejected.
- No changes to other config validations.
---
**Risk**
- Low; no breaking changes expected.